### PR TITLE
MS-2735 - Issues with round-trip diagram fidelity

### DIFF
--- a/source/org/miradi/diagram/DiagramModel.java
+++ b/source/org/miradi/diagram/DiagramModel.java
@@ -860,9 +860,22 @@ abstract public class DiagramModel extends DefaultGraphModel
 		
 		return allFactorCells;
 	}
-	
+
+	public boolean getDeferUpdateGroupBoxCells()
+	{
+		return deferUpdateGroupBoxCells;
+	}
+
+	public void setDeferUpdateGroupBoxCells(boolean value)
+	{
+		deferUpdateGroupBoxCells = value;
+	}
+
 	public void updateGroupBoxCells() throws Exception
 	{
+		if (deferUpdateGroupBoxCells)
+			return;
+
 		Vector<FactorCell> allGroupBoxes = getAllGroupBoxCells();
 		for (int i = 0; i < allGroupBoxes.size(); ++i)
 		{
@@ -921,5 +934,7 @@ abstract public class DiagramModel extends DefaultGraphModel
 	private GraphLayoutCache graphLayoutCache;
 	private boolean isDamaged;
 	private LayerManager layerManager;
+
+	private boolean deferUpdateGroupBoxCells = false;
 }
 

--- a/source/org/miradi/diagram/MouseEventHandler.java
+++ b/source/org/miradi/diagram/MouseEventHandler.java
@@ -160,7 +160,7 @@ public class MouseEventHandler extends MouseAdapter implements GraphSelectionLis
 			FactorMoveHandler factorMoveHandler = new FactorMoveHandler(getProject(), getDiagram().getDiagramModel());
 			factorMoveHandler.factorsWereMovedOrResized(diagramFactorRefs);
 			moveBendPoints();
-			factorMoveHandler.ensureLevelSegementToFirstBendPoint(diagramFactorRefs);
+			factorMoveHandler.ensureLevelSegmentToFirstBendPoint(diagramFactorRefs);
 			
 			synchronizeFactorAndLinkCellsWithStoredObjects();
 		}

--- a/source/org/miradi/views/diagram/NudgeDoer.java
+++ b/source/org/miradi/views/diagram/NudgeDoer.java
@@ -135,7 +135,7 @@ public class NudgeDoer extends LocationDoer
 			FactorMoveHandler factorMoveHandler = new FactorMoveHandler(project, diagramPanel.getDiagramModel());
 			factorMoveHandler.factorsWereMovedOrResized(diagramFactorRefs);
 			moveBendPoints(project, allLinkCells.toArray(new LinkCell[0]), deltaY, deltaX);
-			factorMoveHandler.ensureLevelSegementToFirstBendPoint(diagramFactorRefs);
+			factorMoveHandler.ensureLevelSegmentToFirstBendPoint(diagramFactorRefs);
 		}
 		catch (Exception e)
 		{


### PR DESCRIPTION
* rework auto surround of group box factors (positioning, resizing, etc.)
* defer auto surround of group box factors until end of composite move
* only move group box factors if outside bounds of parent group box
* minor unrelated renames