### PR TITLE
MS-2885 - Update Threats Standard Classification from v 1.1 to v 2.0

### DIFF
--- a/source/org/miradi/dialogs/diagram/FactorSummaryCorePanel.java
+++ b/source/org/miradi/dialogs/diagram/FactorSummaryCorePanel.java
@@ -80,24 +80,25 @@ public class FactorSummaryCorePanel extends ObjectDataInputPanel
 		if(factorToEdit.isStrategy())
 		{
 			addOptionalDraftStatusCheckBox(Strategy.TAG_STATUS);
-			addField(createRadioButtonEditorFieldWithHierarchies(StrategySchema.getObjectType(), Strategy.TAG_STANDARD_CLASSIFICATION_V11_CODE, new StrategyClassificationQuestionV11()));
-			addField(createRadioButtonEditorFieldWithHierarchies(StrategySchema.getObjectType(), Strategy.TAG_STANDARD_CLASSIFICATION_V20_CODE, new StrategyClassificationQuestionV20()));
 			ObjectDataInputField impactField = createRadioButtonEditorField(StrategySchema.getObjectType(), Strategy.TAG_IMPACT_RATING, getQuestion(StrategyImpactQuestion.class));
 			ObjectDataInputField feasibilityField = createRadioButtonEditorField(StrategySchema.getObjectType(), Strategy.TAG_FEASIBILITY_RATING, getQuestion(StrategyFeasibilityQuestion.class));
 			ObjectDataInputField prioritySummaryField = createReadOnlyChoiceField(Strategy.PSEUDO_TAG_RATING_SUMMARY, getQuestion(StrategyRatingSummaryQuestion.class));
 			addFieldsOnOneLine(EAM.text("Rating"), new ObjectDataInputField[] {impactField, feasibilityField, prioritySummaryField});
-			addLabeledSubPanelWithoutBorder(new LegacyTncStrategyRankingEditorPropertiesSubPanel(getProject(), factorToEdit.getRef(), actions), EAM.text("Legacy TNC Ratings"));
+			if (LegacyTncStrategyRankingEditorPropertiesSubPanel.hasLegacyTncRankings(getProject(), factorToEdit.getRef()))
+				addLabeledSubPanelWithoutBorder(new LegacyTncStrategyRankingEditorPropertiesSubPanel(getProject(), factorToEdit.getRef(), actions), EAM.text("Legacy TNC Ratings"));
 			addFieldWithEditButton(EAM.text("Objectives"), createReadOnlyObjectList(StrategySchema.getObjectType(), Strategy.PSEUDO_TAG_RELEVANT_OBJECTIVE_REFS), createObjectsActionButton(actions.getObjectsAction(ActionEditStrategyObjectiveRelevancyList.class), getPicker()));
 			addFieldWithEditButton(EAM.text("Goals"), createReadOnlyObjectList(StrategySchema.getObjectType(), Strategy.PSEUDO_TAG_RELEVANT_GOAL_REFS), createObjectsActionButton(actions.getObjectsAction(ActionEditStrategyGoalRelevancyList.class), getPicker()));
 			addFieldWithEditButton(EAM.text("Indicators"), createReadOnlyObjectList(StrategySchema.getObjectType(), Strategy.PSEUDO_TAG_RELEVANT_INDICATOR_REFS), createObjectsActionButton(actions.getObjectsAction(ActionEditStrategyIndicatorRelevancyList.class), getPicker()));
 			addTaxonomyFields(StrategySchema.getObjectType());
+			addField(createRadioButtonEditorFieldWithHierarchies(StrategySchema.getObjectType(), Strategy.TAG_STANDARD_CLASSIFICATION_V11_CODE, new StrategyClassificationQuestionV11()));
+			addField(createRadioButtonEditorFieldWithHierarchies(StrategySchema.getObjectType(), Strategy.TAG_STANDARD_CLASSIFICATION_V20_CODE, new StrategyClassificationQuestionV20()));
 		}
 
 		if(factorToEdit.isTarget())
 		{
 			addField(createStringField(Target.TAG_SPECIES_LATIN_NAME));
-			addField(createQuestionFieldWithDescriptionPanel(TargetSchema.getObjectType(), Target.TAG_HABITAT_ASSOCIATION, new HabitatAssociationQuestion()));
 			addTaxonomyFields(TargetSchema.getObjectType());
+			addField(createQuestionFieldWithDescriptionPanel(TargetSchema.getObjectType(), Target.TAG_HABITAT_ASSOCIATION, new HabitatAssociationQuestion()));
 		}
 		if (factorToEdit.isHumanWelfareTarget())
 		{

--- a/source/org/miradi/dialogs/diagram/LegacyTncStrategyRankingEditorPropertiesSubPanel.java
+++ b/source/org/miradi/dialogs/diagram/LegacyTncStrategyRankingEditorPropertiesSubPanel.java
@@ -67,13 +67,13 @@ public class LegacyTncStrategyRankingEditorPropertiesSubPanel extends ObjectData
 	private void rebuildThisPropertiesPanel(ORef strategyRef)
 	{
 		removeAll();
-		if (hasLegacyTncRankings(strategyRef))
+		if (hasLegacyTncRankings(getProject(), strategyRef))
 		{
 			add(buttonsPanel);
 		}			
 	}
 
-	private boolean hasLegacyTncRankings(ORef strategyRef)
+	public static boolean hasLegacyTncRankings(Project project, ORef strategyRef)
 	{
 		if (strategyRef.isInvalid())
 			return false;
@@ -81,7 +81,7 @@ public class LegacyTncStrategyRankingEditorPropertiesSubPanel extends ObjectData
 		if (!Strategy.is(strategyRef))
 			return false;
 		
-		Strategy strategy = Strategy.find(getProject(), strategyRef);
+		Strategy strategy = Strategy.find(project, strategyRef);
 		String legacyTncRanking = strategy.getData(Strategy.TAG_LEGACY_TNC_STRATEGY_RANKING);
 		
 		return legacyTncRanking.length() > 0;

--- a/source/org/miradi/dialogs/diagram/StrategyCoreSubPanel.java
+++ b/source/org/miradi/dialogs/diagram/StrategyCoreSubPanel.java
@@ -27,6 +27,7 @@ import org.miradi.dialogfields.ObjectDataInputField;
 import org.miradi.dialogs.base.ObjectDataInputPanel;
 import org.miradi.icons.IconManager;
 import org.miradi.main.EAM;
+import org.miradi.objecthelpers.ORef;
 import org.miradi.objects.Factor;
 import org.miradi.objects.Strategy;
 import org.miradi.project.Project;
@@ -34,9 +35,9 @@ import org.miradi.questions.*;
 import org.miradi.schemas.StrategySchema;
 
 
-public class StrategyCoreSubpanel extends ObjectDataInputPanel
+public class StrategyCoreSubPanel extends ObjectDataInputPanel
 {
-	public StrategyCoreSubpanel(Project projectToUse, Actions actions, int objectType) throws Exception
+	public StrategyCoreSubPanel(Project projectToUse, Actions actions, int objectType) throws Exception
 	{
 		super(projectToUse, objectType);
 
@@ -45,16 +46,17 @@ public class StrategyCoreSubpanel extends ObjectDataInputPanel
 		addFieldsOnOneLine(EAM.text("Strategy"), IconManager.getStrategyIcon(), new ObjectDataInputField[]{shortLabelField, labelField,});
 		addField(createMultilineField(StrategySchema.getObjectType(), Factor.TAG_TEXT));
 
+		addTaxonomyFields(StrategySchema.getObjectType());
 		addField(createRadioButtonEditorFieldWithHierarchies(StrategySchema.getObjectType(), Strategy.TAG_STANDARD_CLASSIFICATION_V11_CODE, new StrategyClassificationQuestionV11()));
 		addField(createRadioButtonEditorFieldWithHierarchies(StrategySchema.getObjectType(), Strategy.TAG_STANDARD_CLASSIFICATION_V20_CODE, new StrategyClassificationQuestionV20()));
-		addTaxonomyFields(StrategySchema.getObjectType());
-		
+
 		ObjectDataInputField impactField = createRadioButtonEditorField(StrategySchema.getObjectType(), Strategy.TAG_IMPACT_RATING, getQuestion(StrategyImpactQuestion.class));
 		ObjectDataInputField feasibilityField = createRadioButtonEditorField(StrategySchema.getObjectType(), Strategy.TAG_FEASIBILITY_RATING, getQuestion(StrategyFeasibilityQuestion.class));
 		ObjectDataInputField prioritySummaryField = createReadOnlyChoiceField(Strategy.PSEUDO_TAG_RATING_SUMMARY, getQuestion(StrategyRatingSummaryQuestion.class));
 		addFieldsOnOneLine(EAM.text("Rating"), new ObjectDataInputField[] {impactField, feasibilityField, prioritySummaryField});
-		
-		addLabeledSubPanelWithoutBorder(new LegacyTncStrategyRankingEditorPropertiesSubPanel(getProject(), getRefForType(StrategySchema.getObjectType()), actions), EAM.text("Legacy TNC Ratings"));
+
+		if (LegacyTncStrategyRankingEditorPropertiesSubPanel.hasLegacyTncRankings(getProject(), getStrategyRef()))
+			addLabeledSubPanelWithoutBorder(new LegacyTncStrategyRankingEditorPropertiesSubPanel(getProject(), getRefForType(StrategySchema.getObjectType()), actions), EAM.text("Legacy TNC Ratings"));
 		
 		addFieldWithEditButton(EAM.text("Objectives"), createReadOnlyObjectList(StrategySchema.getObjectType(), Strategy.PSEUDO_TAG_RELEVANT_OBJECTIVE_REFS), createObjectsActionButton(actions.getObjectsAction(ActionEditStrategyObjectiveRelevancyList.class), getPicker()));
 		addFieldWithEditButton(EAM.text("Goals"), createReadOnlyObjectList(StrategySchema.getObjectType(), Strategy.PSEUDO_TAG_RELEVANT_GOAL_REFS), createObjectsActionButton(actions.getObjectsAction(ActionEditStrategyGoalRelevancyList.class), getPicker()));
@@ -79,4 +81,8 @@ public class StrategyCoreSubpanel extends ObjectDataInputPanel
 		return EAM.text("Summary");
 	}
 
+	private ORef getStrategyRef()
+	{
+		return getSelectedRefs().getRefForType(StrategySchema.getObjectType());
+	}
 }

--- a/source/org/miradi/dialogs/diagram/StrategyPropertiesPanel.java
+++ b/source/org/miradi/dialogs/diagram/StrategyPropertiesPanel.java
@@ -39,7 +39,7 @@ public class StrategyPropertiesPanel extends ObjectDataInputPanelWithSections
 
 		setLayout(new OneColumnGridLayout());
 
-		addSubPanelWithTitledBorder(new StrategyCoreSubpanel(getProject(), getMainWindow().getActions(), StrategySchema.getObjectType()));
+		addSubPanelWithTitledBorder(new StrategyCoreSubPanel(getProject(), getMainWindow().getActions(), StrategySchema.getObjectType()));
 		addSubPanelWithTitledBorder(new RelatedItemsSubpanel(getProject(), StrategySchema.getObjectType()));
 		addSubPanelWithTitledBorder(new FactorSummaryCommentsPanel(getProject(), getProject().getObjectManager().getSchemas().get(ObjectType.STRATEGY)));
 		addSubPanelWithTitledBorder(new ProgressReportSubPanel(getMainWindow()));

--- a/source/org/miradi/dialogs/viability/ModelessTargetSubPanel.java
+++ b/source/org/miradi/dialogs/viability/ModelessTargetSubPanel.java
@@ -37,10 +37,14 @@ public class ModelessTargetSubPanel extends ObjectDataInputPanel
 		if (Target.is(targetType))
 		{
 			addField(createStringField(TargetSchema.getObjectType(), Target.TAG_SPECIES_LATIN_NAME));
-			addField(createEditableCodeListField(TargetSchema.getObjectType(), Target.TAG_HABITAT_ASSOCIATION, StaticQuestionManager.getQuestion(HabitatAssociationQuestion.class)));
 		}
 
 		addTaxonomyFields(targetType);
+		if (Target.is(targetType))
+		{
+			addField(createEditableCodeListField(TargetSchema.getObjectType(), Target.TAG_HABITAT_ASSOCIATION, StaticQuestionManager.getQuestion(HabitatAssociationQuestion.class)));
+		}
+
 		addField(createReadOnlyObjectList(targetType, AbstractTarget.PSEUDO_TAG_CONCEPTUAL_DIAGRAM_REFS));
 		addField(createReadOnlyObjectList(targetType, AbstractTarget.PSEUDO_TAG_RESULTS_CHAIN_REFS));
 

--- a/source/org/miradi/forms/objects/StrategyCoreSubForm.java
+++ b/source/org/miradi/forms/objects/StrategyCoreSubForm.java
@@ -33,11 +33,11 @@ public class StrategyCoreSubForm extends FieldPanelSpec
 		
 		addLabelAndFieldsWithLabels(EAM.text("Strategy"), type, new String[]{Strategy.TAG_SHORT_LABEL, Strategy.TAG_LABEL});
 		addLabelAndField(type, Factor.TAG_TEXT);
-		addLabelAndField(type, Strategy.TAG_STANDARD_CLASSIFICATION_V11_CODE);
-		addLabelAndField(type, Strategy.TAG_STANDARD_CLASSIFICATION_V20_CODE);
 		addLabelAndFieldsWithLabels(EAM.text("Rating"), type, new String[]{Strategy.TAG_IMPACT_RATING, Strategy.TAG_FEASIBILITY_RATING, Strategy.PSEUDO_TAG_RATING_SUMMARY});
 		addLabelAndField(type, Strategy.TAG_LEGACY_TNC_STRATEGY_RANKING);
 		addLabelAndFieldWithLabel(EAM.text("Progress"), type, Strategy.TAG_PROGRESS_REPORT_REFS);
 		addMultipleTaxonomyWithEditButtonFields(type, Strategy.TAG_TAXONOMY_CLASSIFICATION_CONTAINER);
+		addLabelAndField(type, Strategy.TAG_STANDARD_CLASSIFICATION_V11_CODE);
+		addLabelAndField(type, Strategy.TAG_STANDARD_CLASSIFICATION_V20_CODE);
 	}
 }

--- a/source/resources/FieldLabels.properties
+++ b/source/resources/FieldLabels.properties
@@ -468,7 +468,7 @@
 22.Comments = Comments
 22.EvidenceNotes = Evidence Notes
 22.Text = Details
-22.HabitatAssociation = Habitat Association (IUCN v3.0)
+22.HabitatAssociation = IUCN Habitat Associations 3.0
 22.TaxonomyClassificationContainer = Program Classifications
 22.TargetFutureStatus = Target Viability Future Status
 22.FutureStatusJustification = Future Status Justification


### PR DESCRIPTION
* move standard classifications (for target, strategy, threat) below Miradi Share taxonomy classifications
* hide legacy TNC strategy ranking label if panel not applicable
* rename target standard classifications label