### PR TITLE
MS-3022 - bug: Characters not escaped in Rename [Diagram] widget

### DIFF
--- a/source/org/miradi/dialogs/diagram/DiagramTabsLabelPropertiesPanel.java
+++ b/source/org/miradi/dialogs/diagram/DiagramTabsLabelPropertiesPanel.java
@@ -33,7 +33,7 @@ public class DiagramTabsLabelPropertiesPanel extends ObjectDataInputPanel
 		super(projectToUse, diagramObjectRefToUse);
 		
 		ref = diagramObjectRefToUse;
-		addField(createMediumStringField(DiagramObject.TAG_LABEL));
+		addField(createExpandableField(DiagramObject.TAG_LABEL));
 		updateFieldsFromProject();
 	}
 


### PR DESCRIPTION
* diagram name needs formatted_text editor